### PR TITLE
Minimum Node LTS (16)

### DIFF
--- a/.github/workflows/falkor-commander-develop.yml
+++ b/.github/workflows/falkor-commander-develop.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
 
     runs-on: ubuntu-latest
 
@@ -45,10 +45,10 @@ jobs:
         run: |-
           npm run release
 
-      - name: Use Pandoc v2.16.1
+      - name: Use Pandoc v2.18
         uses: r-lib/actions/setup-pandoc@v1
         with:
-          pandoc-version: "2.16.1"
+          pandoc-version: "2.18"
 
       - name: Build Manual
         run: |-

--- a/.github/workflows/falkor-commander-manual.yml
+++ b/.github/workflows/falkor-commander-manual.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     runs-on: ${{ matrix.os }}
@@ -52,11 +52,11 @@ jobs:
         run: |-
           npx --no-install falkor-bundler ${{ github.event.inputs.cli }} --input src/index.ts
 
-      - name: Use Pandoc v2.16.1
+      - name: Use Pandoc v2.18
         if: ${{ matrix.os != 'windows-latest' }}
         uses: r-lib/actions/setup-pandoc@v1
         with:
-          pandoc-version: "2.16.1"
+          pandoc-version: "2.18"
 
       - name: Build Manual
         if: ${{ matrix.os != 'windows-latest' }}

--- a/.github/workflows/falkor-commander-release.yml
+++ b/.github/workflows/falkor-commander-release.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     runs-on: ${{ matrix.os }}
@@ -47,11 +47,11 @@ jobs:
         run: |-
           npm run release
 
-      - name: Use Pandoc v2.16.1
+      - name: Use Pandoc v2.18
         if: ${{ matrix.os != 'windows-latest' }}
         uses: r-lib/actions/setup-pandoc@v1
         with:
-          pandoc-version: "2.16.1"
+          pandoc-version: "2.18"
 
       - name: Build Manual
         if: ${{ matrix.os != 'windows-latest' }}

--- a/.github/workflows/falkor-commander-security.yml
+++ b/.github/workflows/falkor-commander-security.yml
@@ -24,7 +24,7 @@ jobs:
       - name: GitHub Checkout
         uses: actions/checkout@v2
 
-      - name: Analyse Project Dependencies
+      - name: Analyze Project Dependencies
         uses: snyk/actions/node@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -34,5 +34,5 @@ jobs:
         with:
           languages: javascript
 
-      - name: Analyse Project Sources
+      - name: Analyze Project Sources
         uses: github/codeql-action/analyze@v1

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "win32"
       ],
       "dependencies": {
-        "@falkor/falkor-library": "1.1.3",
+        "@falkor/falkor-library": "1.2.0",
         "minimist": "1.2.6",
         "shelljs": "0.8.5"
       },
@@ -32,7 +32,7 @@
         "falkor-commander": ".dist/index.js"
       },
       "devDependencies": {
-        "@falkor/falkor-bundler": "1.1.14",
+        "@falkor/falkor-bundler": "1.2.0",
         "@types/figlet": "1.5.4",
         "@types/minimist": "1.2.2",
         "@types/node": "17.0.40",
@@ -537,9 +537,9 @@
       "dev": true
     },
     "node_modules/@falkor/falkor-bundler": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/@falkor/falkor-bundler/-/falkor-bundler-1.1.14.tgz",
-      "integrity": "sha512-oxkY1C7TxZ9IYCuk1FKZV6yNuLA/PWZR2ZgJqZEAU6LtfagRlQWpiegWWBh/U5bbLg7/AiJ6pRoRQH0IupHAgA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@falkor/falkor-bundler/-/falkor-bundler-1.2.0.tgz",
+      "integrity": "sha512-JcIunVnSwjMQMFyb3VXv2mc5WiJzGi15BIvj9FZjW87BlLQo/cRwzY+APhcwxV1aYI0YYRlkD+W0vgIBspz9rw==",
       "dev": true,
       "funding": [
         {
@@ -575,14 +575,14 @@
         "falkor-bundler": ".dist/index.js"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6"
+        "node": ">=16",
+        "npm": ">=8"
       }
     },
     "node_modules/@falkor/falkor-library": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@falkor/falkor-library/-/falkor-library-1.1.3.tgz",
-      "integrity": "sha512-eXlFUL4OlNysEoK5yVg//omYneyPg1YYCOuqdarRLKPPTUlHmT2rtLcGTBQbrcanN8ZKYsYdXMyXCB38XmHHyw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@falkor/falkor-library/-/falkor-library-1.2.0.tgz",
+      "integrity": "sha512-A4fr00vpktlrztS/vUuBNT5Io2gOa5pqWGdkzhkCDIWK8Ib3/6/IEp2koinZDjgl8jrHo3BWPnGRchS04p7SUQ==",
       "funding": [
         {
           "type": "ko-fi",
@@ -2974,9 +2974,9 @@
       "dev": true
     },
     "@falkor/falkor-bundler": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/@falkor/falkor-bundler/-/falkor-bundler-1.1.14.tgz",
-      "integrity": "sha512-oxkY1C7TxZ9IYCuk1FKZV6yNuLA/PWZR2ZgJqZEAU6LtfagRlQWpiegWWBh/U5bbLg7/AiJ6pRoRQH0IupHAgA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@falkor/falkor-bundler/-/falkor-bundler-1.2.0.tgz",
+      "integrity": "sha512-JcIunVnSwjMQMFyb3VXv2mc5WiJzGi15BIvj9FZjW87BlLQo/cRwzY+APhcwxV1aYI0YYRlkD+W0vgIBspz9rw==",
       "dev": true,
       "requires": {
         "@betit/rollup-plugin-rename-extensions": "0.1.0",
@@ -2995,9 +2995,9 @@
       }
     },
     "@falkor/falkor-library": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@falkor/falkor-library/-/falkor-library-1.1.3.tgz",
-      "integrity": "sha512-eXlFUL4OlNysEoK5yVg//omYneyPg1YYCOuqdarRLKPPTUlHmT2rtLcGTBQbrcanN8ZKYsYdXMyXCB38XmHHyw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@falkor/falkor-library/-/falkor-library-1.2.0.tgz",
+      "integrity": "sha512-A4fr00vpktlrztS/vUuBNT5Io2gOa5pqWGdkzhkCDIWK8Ib3/6/IEp2koinZDjgl8jrHo3BWPnGRchS04p7SUQ==",
       "requires": {
         "@types/figlet": "1.5.4",
         "@types/semver": "7.3.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@falkor/falkor-commander",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@falkor/falkor-commander",
-      "version": "1.1.3",
+      "version": "1.2.0",
       "funding": [
         {
           "type": "ko-fi",
@@ -43,8 +43,8 @@
         "rimraf": "3.0.2"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=6"
+        "node": ">=16",
+        "npm": ">=8"
       },
       "optionalDependencies": {
         "@types/minimist": "1.2.2"

--- a/package.json
+++ b/package.json
@@ -76,12 +76,12 @@
     "rimraf": "3.0.2",
     "prettier": "2.6.2",
     "cspell": "6.1.1",
-    "@falkor/falkor-bundler": "1.1.14"
+    "@falkor/falkor-bundler": "1.2.0"
   },
   "dependencies": {
     "minimist": "1.2.6",
     "shelljs": "0.8.5",
-    "@falkor/falkor-library": "1.1.3"
+    "@falkor/falkor-library": "1.2.0"
   },
   "optionalDependencies": {
     "@types/minimist": "1.2.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falkor/falkor-commander",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Falkor operations commander",
   "author": {
     "name": "Barnabas Bucsy",
@@ -56,8 +56,8 @@
     "win32"
   ],
   "engines": {
-    "node": ">=14",
-    "npm": ">=6"
+    "node": ">=16",
+    "npm": ">=8"
   },
   "scripts": {
     "debug": "rimraf .dist/**/* && falkor-bundler --debug --input src/index.ts",


### PR DESCRIPTION
## Description
Update minimum Node engine version to 16.

## What is the current behavior?
Minimum supported Node engine is >=14.

## What is the new behavior?
Minimum supported Node engine is >=16.

## Does this introduce a breaking change?

* [x] Yes
* [ ] No

## PR Checklist

* [x] Read the [Contribution Guidelines](https://github.com/theonethread/.github/blob/master/.github/contributing.md "Open")
* [x] Code compiles correctly both in `debug` and `release` mode
* [x] Ensured that `npm run prepublishOnly` command generates all necessary release assets
* [x] No new compiler warnings were introduced
* [x] Extended the readme / documentation / CLI help / man file(s) (_where applicable_)
* [x] Dependent changes have been merged and published in downstream modules (_if applicable_)
* [x] All Continuous Integration builds and security checks pass
